### PR TITLE
Standardize Gravatar Avatar URL and Improve Environment Variable Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,27 @@ Run `make help` to see all available commands.
 
 ## Environment Variables
 
-- `GRAVATAR_API_KEY`: Optional API key for Gravatar API. If provided, it will be used for API requests, which may increase rate limits.
+- `GRAVATAR_API_KEY`: Optional API key for Gravatar API. If provided, it will be used for API requests, which increases rate limits and provides access to additional features.
+
+- `GRAVATAR_API_KEY_ENV_VAR`: Optional name of the environment variable that contains the API key. Default is `GRAVATAR_API_KEY`. This is useful if you need to use a different environment variable name in your deployment environment.
+
+When running the server locally, you can set these environment variables in your shell before starting the server:
+
+```bash
+# Set API key (recommended)
+export GRAVATAR_API_KEY=your_api_key_here
+
+# Start the server
+npm start
+```
+
+Or you can provide them inline when starting the server:
+
+```bash
+GRAVATAR_API_KEY=your_api_key_here npm start
+```
+
+When configuring the server in Claude Desktop or VS Code, you can set these environment variables in the configuration as shown in the Setup section above.
 
 ## Troubleshooting
 

--- a/src/config/server-config.ts
+++ b/src/config/server-config.ts
@@ -35,13 +35,12 @@ export const capabilities = {
  * API configuration
  *
  * - avatarBaseUrl: The base URL for Gravatar avatar images
- *   Override with GRAVATAR_AVATAR_BASE_URL environment variable
  *
  * Note: The API base URL is handled by the generated API client
  * and doesn't need to be specified here.
  */
 export const apiConfig = {
-  avatarBaseUrl: process.env.GRAVATAR_AVATAR_BASE_URL || 'https://secure.gravatar.com/avatar',
+  avatarBaseUrl: 'https://gravatar.com/avatar',
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
 
     // We need to cast the arguments to any to avoid TypeScript errors
     // The actual validation happens inside each handler with Zod
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return await handler(request.params.arguments as any);
   } catch (error) {
     if (error instanceof McpError) throw error;

--- a/test/e2e/mcp-server.test.ts
+++ b/test/e2e/mcp-server.test.ts
@@ -155,7 +155,7 @@ describe('MCP Server End-to-End', () => {
       const result = await avatarService.getAvatarById(hash);
 
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -175,7 +175,7 @@ describe('MCP Server End-to-End', () => {
 
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith(email);
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),

--- a/test/integration/avatar-api.test.ts
+++ b/test/integration/avatar-api.test.ts
@@ -56,7 +56,7 @@ describe('Avatar API Integration', () => {
 
       // Verify the mock was called
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -85,7 +85,7 @@ describe('Avatar API Integration', () => {
 
       // Verify the mock was called with the correct URL including query parameters
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=pg`,
+        `https://gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=pg`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -108,7 +108,7 @@ describe('Avatar API Integration', () => {
 
       // Verify the mock was called
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -132,7 +132,7 @@ describe('Avatar API Integration', () => {
       // Verify the mocks were called
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith(email);
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -165,7 +165,7 @@ describe('Avatar API Integration', () => {
       // Verify the mocks were called
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith(email);
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=pg`,
+        `https://gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=pg`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),
@@ -192,7 +192,7 @@ describe('Avatar API Integration', () => {
       // Verify the mocks were called
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith(email);
       expect(fetch).toHaveBeenCalledWith(
-        `https://secure.gravatar.com/avatar/${hash}`,
+        `https://gravatar.com/avatar/${hash}`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),

--- a/test/unit/avatar-service.test.ts
+++ b/test/unit/avatar-service.test.ts
@@ -67,7 +67,7 @@ describe('AvatarService', () => {
     it('should call fetch with correct URL for basic request', async () => {
       await service.getAvatarById('test-hash');
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://secure.gravatar.com/avatar/test-hash',
+        'https://gravatar.com/avatar/test-hash',
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -79,7 +79,7 @@ describe('AvatarService', () => {
     it('should include size parameter when provided', async () => {
       await service.getAvatarById('test-hash', 200);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://secure.gravatar.com/avatar/test-hash?s=200',
+        'https://gravatar.com/avatar/test-hash?s=200',
         expect.any(Object),
       );
     });
@@ -87,7 +87,7 @@ describe('AvatarService', () => {
     it('should include default option parameter when provided', async () => {
       await service.getAvatarById('test-hash', undefined, DefaultAvatarOption.IDENTICON);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://secure.gravatar.com/avatar/test-hash?d=identicon',
+        'https://gravatar.com/avatar/test-hash?d=identicon',
         expect.any(Object),
       );
     });
@@ -95,7 +95,7 @@ describe('AvatarService', () => {
     it('should include force default parameter when true', async () => {
       await service.getAvatarById('test-hash', undefined, undefined, true);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://secure.gravatar.com/avatar/test-hash?f=y',
+        'https://gravatar.com/avatar/test-hash?f=y',
         expect.any(Object),
       );
     });
@@ -103,7 +103,7 @@ describe('AvatarService', () => {
     it('should include rating parameter when provided', async () => {
       await service.getAvatarById('test-hash', undefined, undefined, undefined, Rating.PG);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://secure.gravatar.com/avatar/test-hash?r=pg',
+        'https://gravatar.com/avatar/test-hash?r=pg',
         expect.any(Object),
       );
     });
@@ -113,7 +113,7 @@ describe('AvatarService', () => {
 
       // The order of query parameters might vary, so we'll check for each one separately
       const url = vi.mocked(mockFetch).mock.calls[0][0] as string;
-      expect(url).toContain('https://secure.gravatar.com/avatar/test-hash?');
+      expect(url).toContain('https://gravatar.com/avatar/test-hash?');
       expect(url).toContain('s=100');
       expect(url).toContain('d=robohash');
       expect(url).toContain('f=y');
@@ -338,7 +338,7 @@ describe('Avatar MCP Tools', () => {
       const result = await tool.handler(params);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('https://secure.gravatar.com/avatar/test-hash'),
+        expect.stringContaining('https://gravatar.com/avatar/test-hash'),
         expect.any(Object),
       );
       expect(result).toBeInstanceOf(Buffer);
@@ -381,7 +381,7 @@ describe('Avatar MCP Tools', () => {
 
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith('test@example.com');
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('https://secure.gravatar.com/avatar/email-hash'),
+        expect.stringContaining('https://gravatar.com/avatar/email-hash'),
         expect.any(Object),
       );
       expect(result).toBeInstanceOf(Buffer);


### PR DESCRIPTION
## Summary

This PR standardizes the Gravatar avatar URL to use `https://gravatar.com/avatar` consistently throughout the codebase and improves the environment variables documentation in the README.

## Changes

- __Fixed Avatar Base URL__: Changed the avatar base URL from `https://secure.gravatar.com/avatar` to `https://gravatar.com/avatar` in the server configuration
- __Removed Environment Variable Override__: Removed the ability to override the avatar base URL via an environment variable, ensuring consistent behavior across deployments
- __Updated Tests__: Updated all test files to use the new standardized URL
- __Enhanced Documentation__: Improved the Environment Variables section in the README with clearer explanations and usage examples

## Technical Details

- Modified `src/config/server-config.ts` to use the correct URL and remove the environment variable option

- Updated test assertions in:

  - `test/unit/avatar-service.test.ts`
  - `test/integration/avatar-api.test.ts`
  - `test/e2e/mcp-server.test.ts`

- Expanded the README's Environment Variables section with more detailed information and examples

## Testing

- All tests pass with the new URL configuration
- Verified that the avatar service correctly uses the standardized URL

## Why This Change?

This change ensures that we use the canonical Gravatar avatar URL consistently throughout the codebase.
