### PR TITLE
Remove logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,6 @@ server.setRequestHandler(CallToolRequestSchema, async request => {
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('Gravatar MCP Server running on stdio');
-  console.error(`Version: ${serverInfo.version}`);
 }
 
 runServer().catch(error => {

--- a/src/services/experimental-service.ts
+++ b/src/services/experimental-service.ts
@@ -42,31 +42,23 @@ export class ExperimentalService implements IExperimentalService {
    */
   async getInferredInterestsById(hash: string): Promise<Interest[]> {
     try {
-      console.error(`ExperimentalService.getInferredInterestsById called with hash: ${hash}`);
-
       // Validate hash
       if (!validateHash(hash)) {
-        console.error(`Invalid hash format: ${hash}`);
         throw new GravatarValidationError('Invalid hash format');
       }
 
       // Use API client directly
-      console.error(`Calling ExperimentalApi.getProfileInferredInterestsById for hash: ${hash}`);
       const response = await this.experimentalApiClient.getProfileInferredInterestsById({
         profileIdentifier: hash,
       });
-      console.error(`Received response for hash ${hash}:`, response);
       return response;
     } catch (error: unknown) {
-      console.error(`Error getting inferred interests for hash ${hash}:`, error);
-
       // Handle API errors (moved from adapter)
       if (isApiErrorResponse(error)) {
         const mappedError = await mapHttpStatusToError(
           error.response?.status || 500,
           error.message || 'Failed to fetch inferred interests',
         );
-        console.error(`Mapped error:`, mappedError);
         throw mappedError;
       }
 
@@ -81,22 +73,17 @@ export class ExperimentalService implements IExperimentalService {
    */
   async getInferredInterestsByEmail(email: string): Promise<Interest[]> {
     try {
-      console.error(`ExperimentalService.getInferredInterestsByEmail called with email: ${email}`);
-
       // Validate email
       if (!validateEmail(email)) {
-        console.error(`Invalid email format: ${email}`);
         throw new GravatarValidationError('Invalid email format');
       }
 
       // Generate identifier from email
       const identifier = generateIdentifierFromEmail(email);
-      console.error(`Generated identifier from email: ${identifier}`);
 
       // Use getInferredInterestsById to fetch the inferred interests
       return await this.getInferredInterestsById(identifier);
     } catch (error) {
-      console.error(`Error getting inferred interests for email ${email}:`, error);
       throw error;
     }
   }

--- a/src/services/experimental-service.ts
+++ b/src/services/experimental-service.ts
@@ -72,20 +72,16 @@ export class ExperimentalService implements IExperimentalService {
    * @returns The inferred interests
    */
   async getInferredInterestsByEmail(email: string): Promise<Interest[]> {
-    try {
-      // Validate email
-      if (!validateEmail(email)) {
-        throw new GravatarValidationError('Invalid email format');
-      }
-
-      // Generate identifier from email
-      const identifier = generateIdentifierFromEmail(email);
-
-      // Use getInferredInterestsById to fetch the inferred interests
-      return await this.getInferredInterestsById(identifier);
-    } catch (error) {
-      throw error;
+    // Validate email
+    if (!validateEmail(email)) {
+      throw new GravatarValidationError('Invalid email format');
     }
+
+    // Generate identifier from email
+    const identifier = generateIdentifierFromEmail(email);
+
+    // Use getInferredInterestsById to fetch the inferred interests
+    return await this.getInferredInterestsById(identifier);
   }
 }
 

--- a/src/services/gravatar-image-service.ts
+++ b/src/services/gravatar-image-service.ts
@@ -73,58 +73,54 @@ export class GravatarImageService implements IGravatarImageService {
     forceDefault?: boolean,
     rating?: Rating,
   ): Promise<Buffer> {
-    try {
-      // Validate hash
-      if (!validateHash(hash)) {
-        throw new GravatarValidationError('Invalid hash format');
-      }
-
-      // Build avatar URL using the configured avatarBaseUrl
-      let url = `${apiConfig.avatarBaseUrl}/${hash}`;
-
-      // Add query parameters
-      const queryParams = new URLSearchParams();
-
-      if (size) {
-        queryParams.append('s', size.toString());
-      }
-
-      if (defaultOption) {
-        queryParams.append('d', defaultOption);
-      }
-
-      if (forceDefault) {
-        queryParams.append('f', 'y');
-      }
-
-      if (rating) {
-        queryParams.append('r', rating);
-      }
-
-      // Add query string to URL if there are any parameters
-      const queryString = queryParams.toString();
-      if (queryString) {
-        url += `?${queryString}`;
-      }
-
-      // Fetch the image from the URL with User-Agent header
-      const response = await this.gravatarImageApiClient(url, {
-        headers: {
-          'User-Agent': getUserAgent(),
-        },
-      });
-
-      if (!response.ok) {
-        throw new GravatarValidationError(`Failed to fetch avatar: ${response.statusText}`);
-      }
-
-      // Convert the response to a buffer
-      const arrayBuffer = await response.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      return buffer;
-    } catch (error) {
-      throw error;
+    // Validate hash
+    if (!validateHash(hash)) {
+      throw new GravatarValidationError('Invalid hash format');
     }
+
+    // Build avatar URL using the configured avatarBaseUrl
+    let url = `${apiConfig.avatarBaseUrl}/${hash}`;
+
+    // Add query parameters
+    const queryParams = new URLSearchParams();
+
+    if (size) {
+      queryParams.append('s', size.toString());
+    }
+
+    if (defaultOption) {
+      queryParams.append('d', defaultOption);
+    }
+
+    if (forceDefault) {
+      queryParams.append('f', 'y');
+    }
+
+    if (rating) {
+      queryParams.append('r', rating);
+    }
+
+    // Add query string to URL if there are any parameters
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+
+    // Fetch the image from the URL with User-Agent header
+    const response = await this.gravatarImageApiClient(url, {
+      headers: {
+        'User-Agent': getUserAgent(),
+      },
+    });
+
+    if (!response.ok) {
+      throw new GravatarValidationError(`Failed to fetch avatar: ${response.statusText}`);
+    }
+
+    // Convert the response to a buffer
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    return buffer;
   }
 
   /**
@@ -143,20 +139,16 @@ export class GravatarImageService implements IGravatarImageService {
     forceDefault?: boolean,
     rating?: Rating,
   ): Promise<Buffer> {
-    try {
-      // Validate email
-      if (!validateEmail(email)) {
-        throw new GravatarValidationError('Invalid email format');
-      }
-
-      // Generate identifier from email
-      const identifier = generateIdentifierFromEmail(email);
-
-      // Use getAvatarById to get the avatar
-      return await this.getAvatarById(identifier, size, defaultOption, forceDefault, rating);
-    } catch (error) {
-      throw error;
+    // Validate email
+    if (!validateEmail(email)) {
+      throw new GravatarValidationError('Invalid email format');
     }
+
+    // Generate identifier from email
+    const identifier = generateIdentifierFromEmail(email);
+
+    // Use getAvatarById to get the avatar
+    return await this.getAvatarById(identifier, size, defaultOption, forceDefault, rating);
   }
 }
 

--- a/src/services/gravatar-image-service.ts
+++ b/src/services/gravatar-image-service.ts
@@ -74,13 +74,8 @@ export class GravatarImageService implements IGravatarImageService {
     rating?: Rating,
   ): Promise<Buffer> {
     try {
-      console.error(
-        `GravatarImageService.getAvatarById called with hash: ${hash}, size: ${size}, defaultOption: ${defaultOption}, forceDefault: ${forceDefault}, rating: ${rating}`,
-      );
-
       // Validate hash
       if (!validateHash(hash)) {
-        console.error(`Invalid hash format: ${hash}`);
         throw new GravatarValidationError('Invalid hash format');
       }
 
@@ -112,8 +107,6 @@ export class GravatarImageService implements IGravatarImageService {
         url += `?${queryString}`;
       }
 
-      console.error(`Making request to URL: ${url}`);
-
       // Fetch the image from the URL with User-Agent header
       const response = await this.gravatarImageApiClient(url, {
         headers: {
@@ -121,20 +114,15 @@ export class GravatarImageService implements IGravatarImageService {
         },
       });
 
-      console.error(`Received response with status: ${response.status} ${response.statusText}`);
-
       if (!response.ok) {
-        console.error(`Failed to fetch avatar: ${response.statusText}`);
         throw new GravatarValidationError(`Failed to fetch avatar: ${response.statusText}`);
       }
 
       // Convert the response to a buffer
       const arrayBuffer = await response.arrayBuffer();
       const buffer = Buffer.from(arrayBuffer);
-      console.error(`Successfully converted response to buffer of size: ${buffer.length} bytes`);
       return buffer;
     } catch (error) {
-      console.error(`Error getting avatar for hash ${hash}:`, error);
       throw error;
     }
   }
@@ -156,24 +144,17 @@ export class GravatarImageService implements IGravatarImageService {
     rating?: Rating,
   ): Promise<Buffer> {
     try {
-      console.error(
-        `GravatarImageService.getAvatarByEmail called with email: ${email}, size: ${size}, defaultOption: ${defaultOption}, forceDefault: ${forceDefault}, rating: ${rating}`,
-      );
-
       // Validate email
       if (!validateEmail(email)) {
-        console.error(`Invalid email format: ${email}`);
         throw new GravatarValidationError('Invalid email format');
       }
 
       // Generate identifier from email
       const identifier = generateIdentifierFromEmail(email);
-      console.error(`Generated identifier from email: ${identifier}`);
 
       // Use getAvatarById to get the avatar
       return await this.getAvatarById(identifier, size, defaultOption, forceDefault, rating);
     } catch (error) {
-      console.error(`Error getting avatar for email ${email}:`, error);
       throw error;
     }
   }

--- a/src/services/profile-service.ts
+++ b/src/services/profile-service.ts
@@ -42,29 +42,21 @@ export class ProfileService implements IProfileService {
    */
   async getProfileById(hash: string): Promise<Profile> {
     try {
-      console.error(`ProfileService.getProfileById called with hash: ${hash}`);
-
       // Validate hash
       if (!validateHash(hash)) {
-        console.error(`Invalid hash format: ${hash}`);
         throw new GravatarValidationError('Invalid hash format');
       }
 
       // Use API client directly
-      console.error(`Calling ProfilesApi.getProfileById for hash: ${hash}`);
       const response = await this.profilesApiClient.getProfileById({ profileIdentifier: hash });
-      console.error(`Received response for hash ${hash}:`, response);
       return response;
     } catch (error: unknown) {
-      console.error(`Error getting profile for hash ${hash}:`, error);
-
       // Handle API errors (moved from adapter)
       if (isApiErrorResponse(error)) {
         const mappedError = await mapHttpStatusToError(
           error.response?.status || 500,
           error.message || 'Failed to fetch profile',
         );
-        console.error(`Mapped error:`, mappedError);
         throw mappedError;
       }
 
@@ -79,22 +71,17 @@ export class ProfileService implements IProfileService {
    */
   async getProfileByEmail(email: string): Promise<Profile> {
     try {
-      console.error(`ProfileService.getProfileByEmail called with email: ${email}`);
-
       // Validate email
       if (!validateEmail(email)) {
-        console.error(`Invalid email format: ${email}`);
         throw new GravatarValidationError('Invalid email format');
       }
 
       // Generate identifier from email
       const identifier = generateIdentifierFromEmail(email);
-      console.error(`Generated identifier from email: ${identifier}`);
 
       // Use getProfileById to fetch the profile
       return await this.getProfileById(identifier);
     } catch (error) {
-      console.error(`Error getting profile for email ${email}:`, error);
       throw error;
     }
   }

--- a/src/services/profile-service.ts
+++ b/src/services/profile-service.ts
@@ -70,20 +70,16 @@ export class ProfileService implements IProfileService {
    * @returns The profile data
    */
   async getProfileByEmail(email: string): Promise<Profile> {
-    try {
-      // Validate email
-      if (!validateEmail(email)) {
-        throw new GravatarValidationError('Invalid email format');
-      }
-
-      // Generate identifier from email
-      const identifier = generateIdentifierFromEmail(email);
-
-      // Use getProfileById to fetch the profile
-      return await this.getProfileById(identifier);
-    } catch (error) {
-      throw error;
+    // Validate email
+    if (!validateEmail(email)) {
+      throw new GravatarValidationError('Invalid email format');
     }
+
+    // Generate identifier from email
+    const identifier = generateIdentifierFromEmail(email);
+
+    // Use getProfileById to fetch the profile
+    return await this.getProfileById(identifier);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR removes all `console.error` statements from the codebase (except for fatal error logging) and fixes the resulting linting errors by removing unnecessary try/catch blocks.

## Changes

- Removed all `console.error` statements from service files:

  - `src/services/gravatar-image-service.ts`
  - `src/services/profile-service.ts`
  - `src/services/experimental-service.ts`

- Removed server startup logging in `src/index.ts` while preserving fatal error logging

- Fixed linting errors by removing unnecessary try/catch blocks in:

  - `getInferredInterestsByEmail` in experimental-service.ts
  - `getProfileByEmail` in profile-service.ts
  - `getAvatarById` and `getAvatarByEmail` in gravatar-image-service.ts

## Testing

- All tests pass
- Linting passes with no errors

## Why

This cleans up the test output considerably. It also makes the code base easier to read and reason about.

Eventually we may want to add logging for debugging.  If so, we can include support for a basic logging system, enabled by the presence of an environment variable (e.g. `GRAVATAR_DEBUG`).
