### PR TITLE
Rename parameters from hash to context-specific identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Gravatar's official MCP Server, enabling Claude to interact with Gravatar avatar
 ## Tools
 
 1. `get_profile_by_id`
-   - Fetch a Gravatar profile using a profile identifier (hash).
+   - Fetch a Gravatar profile using a profile identifier.
    - Required inputs:
-     - `hash` (string): The profile identifier (MD5 or SHA256 hash)
+     - `profileIdentifier` (string): The profile identifier (SHA256 or MD5 hash)
    - Returns: Profile object as JSON with user information
 
 2. `get_profile_by_email`
@@ -17,9 +17,9 @@ Gravatar's official MCP Server, enabling Claude to interact with Gravatar avatar
    - Returns: Profile object as JSON with user information
 
 3. `get_inferred_interests_by_id`
-   - Fetch inferred interests for a Gravatar profile using a profile identifier (hash).
+   - Fetch inferred interests for a Gravatar profile using a profile identifier.
    - Required inputs:
-     - `hash` (string): The profile identifier (MD5 or SHA256 hash)
+     - `profileIdentifier` (string): The profile identifier (SHA256 or MD5 hash)
    - Returns: List of inferred interest names as JSON
 
 4. `get_inferred_interests_by_email`
@@ -29,9 +29,9 @@ Gravatar's official MCP Server, enabling Claude to interact with Gravatar avatar
    - Returns: List of inferred interest names as JSON
 
 5. `get_avatar_by_id`
-   - Get the avatar PNG image for a Gravatar profile using a profile identifier (hash).
+   - Get the avatar PNG image for a Gravatar profile using an avatar identifier.
    - Required inputs:
-     - `hash` (string): The profile identifier (MD5 or SHA256 hash)
+     - `avatarIdentifier` (string): The avatar identifier (SHA256 or MD5 hash)
    - Optional inputs:
      - `size` (number, default: undefined): Preferred size of the avatar (1-2048 pixels)
      - `defaultOption` (string, default: undefined): Default avatar option if no avatar exists

--- a/src/apis/avatar-image-api.ts
+++ b/src/apis/avatar-image-api.ts
@@ -4,7 +4,7 @@ import type { DefaultAvatarOption, Rating } from '../common/types.js';
 import { apiConfig } from '../config/server-config.js';
 
 export interface GetAvatarByIdParams {
-  hash: string;
+  avatarIdentifier: string;
   size?: number;
   defaultOption?: DefaultAvatarOption;
   forceDefault?: boolean;
@@ -19,12 +19,12 @@ export class AvatarImageApi {
    * Get a Gravatar image by its identifier
    */
   async getAvatarById(params: GetAvatarByIdParams): Promise<Buffer> {
-    if (!validateHash(params.hash)) {
-      throw new GravatarValidationError('Invalid hash format');
+    if (!validateHash(params.avatarIdentifier)) {
+      throw new GravatarValidationError('Invalid identifier format');
     }
 
     // Build avatar URL
-    let url = `${apiConfig.avatarBaseUrl}/${params.hash}`;
+    let url = `${apiConfig.avatarBaseUrl}/${params.avatarIdentifier}`;
     const queryParams = new URLSearchParams();
 
     if (params.size) {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,26 +1,4 @@
 /**
- * Input parameters for profile-related operations
- */
-export interface ProfileParams {
-  hash?: string;
-  email?: string;
-}
-
-/**
- * Input parameters for avatar-related operations
- */
-export interface AvatarParams {
-  hash?: string;
-  email?: string;
-  preferredSize?: number;
-  defaultAvatarOption?: DefaultAvatarOption;
-  forceDefault?: boolean;
-  rating?: Rating;
-  initials?: string;
-  name?: string;
-}
-
-/**
  * Default avatar options
  */
 export enum DefaultAvatarOption {

--- a/src/tools/get-avatar-by-email.ts
+++ b/src/tools/get-avatar-by-email.ts
@@ -39,12 +39,12 @@ export async function handler(params: z.infer<typeof getAvatarByEmailSchema>) {
   }
 
   // Generate identifier from email
-  const hash = generateIdentifierFromEmail(params.email);
+  const avatarIdentifier = generateIdentifierFromEmail(params.email);
 
   // Use API client to get avatar by ID
   const apiClient = await createApiClient();
   const avatarBuffer = await apiClient.avatars.getAvatarById({
-    hash,
+    avatarIdentifier: avatarIdentifier,
     size: params.size,
     defaultOption: params.defaultOption,
     forceDefault: params.forceDefault,

--- a/src/tools/get-avatar-by-id.ts
+++ b/src/tools/get-avatar-by-id.ts
@@ -6,9 +6,9 @@ import { createApiClient } from '../apis/api-client.js';
 
 // Schema definition
 export const getAvatarByIdSchema = z.object({
-  hash: z.string().refine(validateHash, {
+  avatarIdentifier: z.string().refine(validateHash, {
     message:
-      'Invalid hash format. Must be a 32-character (MD5) or 64-character (SHA256) hexadecimal string.',
+      'Invalid identifier format. Must be a 64-character (SHA256) or 32-character (MD5, deprecated) hexadecimal string.',
   }),
   size: z.preprocess(val => (val === '' ? undefined : val), z.number().min(1).max(2048).optional()),
   defaultOption: z.preprocess(
@@ -27,7 +27,7 @@ export const getAvatarByIdSchema = z.object({
 // Tool definition
 export const getAvatarByIdTool = {
   name: 'get_avatar_by_id',
-  description: 'Get the avatar PNG image for a Gravatar profile using a profile identifier (hash).',
+  description: 'Get the avatar PNG image for a Gravatar profile using an avatar identifier.',
   inputSchema: zodToJsonSchema(getAvatarByIdSchema),
 };
 
@@ -35,7 +35,7 @@ export const getAvatarByIdTool = {
 export async function handler(params: z.infer<typeof getAvatarByIdSchema>) {
   const apiClient = await createApiClient();
   const avatarBuffer = await apiClient.avatars.getAvatarById({
-    hash: params.hash,
+    avatarIdentifier: params.avatarIdentifier,
     size: params.size,
     defaultOption: params.defaultOption,
     forceDefault: params.forceDefault,

--- a/src/tools/get-interests-by-email.ts
+++ b/src/tools/get-interests-by-email.ts
@@ -26,12 +26,12 @@ export async function handler(params: z.infer<typeof getInferredInterestsByEmail
   }
 
   // Generate identifier from email
-  const hash = generateIdentifierFromEmail(params.email);
+  const profileIdentifier = generateIdentifierFromEmail(params.email);
 
   // Use API client to get interests by ID
   const apiClient = await createApiClient();
   const interests = await apiClient.experimental.getProfileInferredInterestsById({
-    profileIdentifier: hash,
+    profileIdentifier: profileIdentifier,
   });
 
   // Extract just the name field from each interest

--- a/src/tools/get-interests-by-id.ts
+++ b/src/tools/get-interests-by-id.ts
@@ -6,30 +6,30 @@ import { GravatarValidationError } from '../common/errors.js';
 
 // Schema definition
 export const getInferredInterestsByIdSchema = z.object({
-  hash: z.string().refine(validateHash, {
+  profileIdentifier: z.string().refine(validateHash, {
     message:
-      'Invalid hash format. Must be a 32-character (MD5) or 64-character (SHA256) hexadecimal string.',
+      'Invalid identifier format. Must be a 64-character (SHA256) or 32-character (MD5, deprecated) hexadecimal string.',
   }),
 });
 
 // Tool definition
 export const getInterestsByIdTool = {
   name: 'get_inferred_interests_by_id',
-  description: 'Fetch inferred interests for a Gravatar profile using a profile identifier (hash).',
+  description: 'Fetch inferred interests for a Gravatar profile using a profile identifier.',
   inputSchema: zodToJsonSchema(getInferredInterestsByIdSchema),
 };
 
 // Tool handler
 export async function handler(params: z.infer<typeof getInferredInterestsByIdSchema>) {
-  // Validate hash
-  if (!validateHash(params.hash)) {
-    throw new GravatarValidationError('Invalid hash format');
+  // Validate identifier
+  if (!validateHash(params.profileIdentifier)) {
+    throw new GravatarValidationError('Invalid identifier format');
   }
 
   // Use API client to get interests by ID
   const apiClient = await createApiClient();
   const interests = await apiClient.experimental.getProfileInferredInterestsById({
-    profileIdentifier: params.hash,
+    profileIdentifier: params.profileIdentifier,
   });
 
   // Extract just the name field from each interest

--- a/src/tools/get-profile-by-email.ts
+++ b/src/tools/get-profile-by-email.ts
@@ -26,12 +26,12 @@ export async function handler(params: z.infer<typeof getProfileByEmailSchema>) {
   }
 
   // Generate identifier from email
-  const hash = generateIdentifierFromEmail(params.email);
+  const profileIdentifier = generateIdentifierFromEmail(params.email);
 
   // Use API client to get profile by ID
   const apiClient = await createApiClient();
   const profile = await apiClient.profiles.getProfileById({
-    profileIdentifier: hash,
+    profileIdentifier: profileIdentifier,
   });
 
   return {

--- a/src/tools/get-profile-by-id.ts
+++ b/src/tools/get-profile-by-id.ts
@@ -5,16 +5,16 @@ import { validateHash } from '../common/utils.js';
 
 // Schema definition (moved from service)
 export const getProfileByIdSchema = z.object({
-  hash: z.string().refine(validateHash, {
+  profileIdentifier: z.string().refine(validateHash, {
     message:
-      'Invalid hash format. Must be a 32-character (MD5) or 64-character (SHA256) hexadecimal string.',
+      'Invalid identifier format. Must be a 64-character (SHA256) or 32-character (MD5, deprecated) hexadecimal string.',
   }),
 });
 
 // Tool definition
 export const getProfileByIdTool = {
   name: 'get_profile_by_id',
-  description: 'Fetch a Gravatar profile using a profile identifier (hash).',
+  description: 'Fetch a Gravatar profile using a profile identifier.',
   inputSchema: zodToJsonSchema(getProfileByIdSchema),
 };
 
@@ -22,7 +22,7 @@ export const getProfileByIdTool = {
 export async function handler(params: z.infer<typeof getProfileByIdSchema>) {
   const apiClient = await createApiClient();
   const profile = await apiClient.profiles.getProfileById({
-    profileIdentifier: params.hash,
+    profileIdentifier: params.profileIdentifier,
   });
   return {
     content: [{ type: 'text', text: JSON.stringify(profile, null, 2) }],

--- a/test/e2e/mcp-server.test.ts
+++ b/test/e2e/mcp-server.test.ts
@@ -167,7 +167,7 @@ describe('MCP Server End-to-End', () => {
 
   describe('Gravatar Image Operations', () => {
     it('getAvatarById should return avatar data', async () => {
-      const result = await avatarImageApi.getAvatarById({ hash });
+      const result = await avatarImageApi.getAvatarById({ avatarIdentifier: hash });
 
       expect(result).toBeDefined();
       expect(result).toBeInstanceOf(Buffer);
@@ -182,7 +182,7 @@ describe('MCP Server End-to-End', () => {
       const emailHash = utils.generateIdentifierFromEmail(email);
 
       // Call the API with the generated hash
-      const result = await avatarImageApi.getAvatarById({ hash: emailHash });
+      const result = await avatarImageApi.getAvatarById({ avatarIdentifier: emailHash });
 
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith(email);
       expect(result).toBeDefined();

--- a/test/integration/avatar-image-api-integration.test.ts
+++ b/test/integration/avatar-image-api-integration.test.ts
@@ -53,7 +53,7 @@ describe('AvatarImageApi Integration', () => {
       vi.mocked(fetch).mockResolvedValue(createMockResponse() as any);
 
       // Call the function
-      const result = await avatarImageApi.getAvatarById({ hash });
+      const result = await avatarImageApi.getAvatarById({ avatarIdentifier: hash });
 
       // Verify the mock was called
       expect(fetch).toHaveBeenCalledWith(
@@ -77,7 +77,7 @@ describe('AvatarImageApi Integration', () => {
 
       // Call the function with parameters
       const result = await avatarImageApi.getAvatarById({
-        hash,
+        avatarIdentifier: hash,
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -105,7 +105,7 @@ describe('AvatarImageApi Integration', () => {
       vi.mocked(fetch).mockResolvedValue(createMockResponse(404, 'Not Found') as any);
 
       // Call the function and expect it to throw
-      await expect(avatarImageApi.getAvatarById({ hash })).rejects.toThrow();
+      await expect(avatarImageApi.getAvatarById({ avatarIdentifier: hash })).rejects.toThrow();
 
       // Verify the mock was called
       expect(fetch).toHaveBeenCalledWith(

--- a/test/unit/avatar-image-api.test.ts
+++ b/test/unit/avatar-image-api.test.ts
@@ -91,22 +91,22 @@ describe('AvatarImageApi', () => {
 
   describe('getAvatarById', () => {
     it('should validate the hash', async () => {
-      await api.getAvatarById({ hash: 'test-hash' });
+      await api.getAvatarById({ avatarIdentifier: 'test-hash' });
       expect(utils.validateHash).toHaveBeenCalledWith('test-hash');
     });
 
     it('should throw GravatarValidationError for invalid hash', async () => {
       vi.mocked(utils.validateHash).mockReturnValue(false);
-      await expect(api.getAvatarById({ hash: 'invalid-hash' })).rejects.toThrow(
+      await expect(api.getAvatarById({ avatarIdentifier: 'invalid-hash' })).rejects.toThrow(
         GravatarValidationError,
       );
-      await expect(api.getAvatarById({ hash: 'invalid-hash' })).rejects.toThrow(
-        'Invalid hash format',
+      await expect(api.getAvatarById({ avatarIdentifier: 'invalid-hash' })).rejects.toThrow(
+        'Invalid identifier format',
       );
     });
 
     it('should call fetch with correct URL for basic request', async () => {
-      await api.getAvatarById({ hash: 'test-hash' });
+      await api.getAvatarById({ avatarIdentifier: 'test-hash' });
       expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -115,7 +115,7 @@ describe('AvatarImageApi', () => {
     });
 
     it('should include size parameter in URL when provided', async () => {
-      await api.getAvatarById({ hash: 'test-hash', size: 200 });
+      await api.getAvatarById({ avatarIdentifier: 'test-hash', size: 200 });
       expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?s=200', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -124,7 +124,10 @@ describe('AvatarImageApi', () => {
     });
 
     it('should include default option parameter in URL when provided', async () => {
-      await api.getAvatarById({ hash: 'test-hash', defaultOption: DefaultAvatarOption.IDENTICON });
+      await api.getAvatarById({
+        avatarIdentifier: 'test-hash',
+        defaultOption: DefaultAvatarOption.IDENTICON,
+      });
       expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?d=identicon', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -133,7 +136,7 @@ describe('AvatarImageApi', () => {
     });
 
     it('should include force default parameter in URL when true', async () => {
-      await api.getAvatarById({ hash: 'test-hash', forceDefault: true });
+      await api.getAvatarById({ avatarIdentifier: 'test-hash', forceDefault: true });
       expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?f=y', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -142,7 +145,7 @@ describe('AvatarImageApi', () => {
     });
 
     it('should include rating parameter in URL when provided', async () => {
-      await api.getAvatarById({ hash: 'test-hash', rating: Rating.PG });
+      await api.getAvatarById({ avatarIdentifier: 'test-hash', rating: Rating.PG });
       expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?r=pg', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -152,7 +155,7 @@ describe('AvatarImageApi', () => {
 
     it('should include all parameters in URL when provided', async () => {
       await api.getAvatarById({
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: 100,
         defaultOption: DefaultAvatarOption.ROBOHASH,
         forceDefault: true,
@@ -175,7 +178,7 @@ describe('AvatarImageApi', () => {
       });
       global.fetch = mockFetch;
 
-      const result = await api.getAvatarById({ hash: 'test-hash' });
+      const result = await api.getAvatarById({ avatarIdentifier: 'test-hash' });
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBe(20);
@@ -189,8 +192,10 @@ describe('AvatarImageApi', () => {
       });
       global.fetch = mockFetch;
 
-      await expect(api.getAvatarById({ hash: 'test-hash' })).rejects.toThrow('Fetch error');
-      await expect(api.getAvatarById({ hash: 'test-hash' })).rejects.toThrow(error);
+      await expect(api.getAvatarById({ avatarIdentifier: 'test-hash' })).rejects.toThrow(
+        'Fetch error',
+      );
+      await expect(api.getAvatarById({ avatarIdentifier: 'test-hash' })).rejects.toThrow(error);
     });
 
     it('should handle non-ok responses', async () => {
@@ -199,10 +204,10 @@ describe('AvatarImageApi', () => {
       });
       global.fetch = mockFetch;
 
-      await expect(api.getAvatarById({ hash: 'test-hash' })).rejects.toThrow(
+      await expect(api.getAvatarById({ avatarIdentifier: 'test-hash' })).rejects.toThrow(
         GravatarValidationError,
       );
-      await expect(api.getAvatarById({ hash: 'test-hash' })).rejects.toThrow(
+      await expect(api.getAvatarById({ avatarIdentifier: 'test-hash' })).rejects.toThrow(
         'Failed to fetch avatar',
       );
     });
@@ -239,7 +244,7 @@ describe('Gravatar Image MCP Tools', () => {
     vi.mocked(getAvatarByIdHandler).mockImplementation(async (params: any) => {
       const apiClient = await createApiClient();
       const avatarBuffer = await apiClient.avatars.getAvatarById({
-        hash: params.hash,
+        avatarIdentifier: params.avatarIdentifier,
         size: params.size,
         defaultOption: params.defaultOption,
         forceDefault: params.forceDefault,
@@ -258,12 +263,12 @@ describe('Gravatar Image MCP Tools', () => {
 
     vi.mocked(getAvatarByEmailHandler).mockImplementation(async (params: any) => {
       // Generate hash from email
-      const hash = utils.generateIdentifierFromEmail(params.email);
+      const avatarIdentifier = utils.generateIdentifierFromEmail(params.email);
 
       // Use API client to get avatar by ID
       const apiClient = await createApiClient();
       const avatarBuffer = await apiClient.avatars.getAvatarById({
-        hash,
+        avatarIdentifier,
         size: params.size,
         defaultOption: params.defaultOption,
         forceDefault: params.forceDefault,
@@ -291,14 +296,14 @@ describe('Gravatar Image MCP Tools', () => {
       const tool = getAvatarByIdTool;
       expect(tool.name).toBe('get_avatar_by_id');
       expect(tool.description).toContain(
-        'Get the avatar PNG image for a Gravatar profile using a profile identifier (hash)',
+        'Get the avatar PNG image for a Gravatar profile using an avatar identifier',
       );
     });
 
     it('should call the API client with correct parameters', async () => {
       // Use type assertion to tell TypeScript this is the correct type
       const params = {
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -309,7 +314,7 @@ describe('Gravatar Image MCP Tools', () => {
 
       expect(createApiClient).toHaveBeenCalled();
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -328,7 +333,7 @@ describe('Gravatar Image MCP Tools', () => {
 
       // Use type assertion to tell TypeScript this is the correct type
       const params = {
-        hash: 'invalid-hash',
+        avatarIdentifier: 'invalid-hash',
       } as any;
 
       await expect(getAvatarByIdHandler(params)).rejects.toThrow(GravatarValidationError);
@@ -359,7 +364,7 @@ describe('Gravatar Image MCP Tools', () => {
       expect(createApiClient).toHaveBeenCalled();
       expect(utils.generateIdentifierFromEmail).toHaveBeenCalledWith('test@example.com');
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'email-hash',
+        avatarIdentifier: 'email-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -113,7 +113,7 @@ describe('Profile Tool Handlers', () => {
 
   describe('getProfileById handler', () => {
     it('should call the service with correct parameters', async () => {
-      const params = { hash: 'test-hash' };
+      const params = { profileIdentifier: 'test-hash' };
       const result = await getProfileByIdHandler(params);
 
       expect(createApiClient).toHaveBeenCalled();
@@ -143,12 +143,12 @@ describe('Profile Tool Handlers', () => {
     it('should handle service errors', async () => {
       // Setup the API client to throw an error
       mockApiClient.profiles.getProfileById.mockRejectedValue(
-        new GravatarValidationError('Invalid hash format'),
+        new GravatarValidationError('Invalid identifier format'),
       );
 
-      const params = { hash: 'invalid-hash' };
+      const params = { profileIdentifier: 'invalid-identifier' };
       await expect(getProfileByIdHandler(params)).rejects.toThrow(GravatarValidationError);
-      await expect(getProfileByIdHandler(params)).rejects.toThrow('Invalid hash format');
+      await expect(getProfileByIdHandler(params)).rejects.toThrow('Invalid identifier format');
     });
   });
 
@@ -239,7 +239,7 @@ describe('Experimental Tool Handlers', () => {
 
   describe('getInterestsById handler', () => {
     it('should call the service with correct parameters', async () => {
-      const params = { hash: 'test-hash' };
+      const params = { profileIdentifier: 'test-hash' };
       const result = await getInterestsByIdHandler(params);
 
       expect(createApiClient).toHaveBeenCalled();
@@ -263,12 +263,12 @@ describe('Experimental Tool Handlers', () => {
     it('should handle service errors', async () => {
       // Setup the API client to throw an error
       mockApiClient.experimental.getProfileInferredInterestsById.mockRejectedValue(
-        new GravatarValidationError('Invalid hash format'),
+        new GravatarValidationError('Invalid identifier format'),
       );
 
-      const params = { hash: 'invalid-hash' };
+      const params = { profileIdentifier: 'invalid-identifier' };
       await expect(getInterestsByIdHandler(params)).rejects.toThrow(GravatarValidationError);
-      await expect(getInterestsByIdHandler(params)).rejects.toThrow('Invalid hash format');
+      await expect(getInterestsByIdHandler(params)).rejects.toThrow('Invalid identifier format');
     });
   });
 
@@ -353,7 +353,7 @@ describe('Avatar Tool Handlers', () => {
   describe('getAvatarById handler', () => {
     it('should call the API client with correct parameters', async () => {
       const params = {
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -364,7 +364,7 @@ describe('Avatar Tool Handlers', () => {
 
       expect(createApiClient).toHaveBeenCalled();
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -384,12 +384,12 @@ describe('Avatar Tool Handlers', () => {
     });
 
     it('should handle minimal parameters', async () => {
-      const params = { hash: 'test-hash' };
+      const params = { avatarIdentifier: 'test-hash' };
 
       await getAvatarByIdHandler(params);
 
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'test-hash',
+        avatarIdentifier: 'test-hash',
         size: undefined,
         defaultOption: undefined,
         forceDefault: undefined,
@@ -400,12 +400,12 @@ describe('Avatar Tool Handlers', () => {
     it('should handle service errors', async () => {
       // Setup the API client to throw an error
       mockApiClient.avatars.getAvatarById.mockRejectedValue(
-        new GravatarValidationError('Invalid hash format'),
+        new GravatarValidationError('Invalid identifier format'),
       );
 
-      const params = { hash: 'invalid-hash' };
+      const params = { avatarIdentifier: 'invalid-identifier' };
       await expect(getAvatarByIdHandler(params)).rejects.toThrow(GravatarValidationError);
-      await expect(getAvatarByIdHandler(params)).rejects.toThrow('Invalid hash format');
+      await expect(getAvatarByIdHandler(params)).rejects.toThrow('Invalid identifier format');
     });
   });
 
@@ -427,7 +427,7 @@ describe('Avatar Tool Handlers', () => {
 
       expect(createApiClient).toHaveBeenCalled();
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'email-hash',
+        avatarIdentifier: 'email-hash',
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
@@ -456,7 +456,7 @@ describe('Avatar Tool Handlers', () => {
       await getAvatarByEmailHandler(params);
 
       expect(mockApiClient.avatars.getAvatarById).toHaveBeenCalledWith({
-        hash: 'email-hash',
+        avatarIdentifier: 'email-hash',
         size: undefined,
         defaultOption: undefined,
         forceDefault: undefined,


### PR DESCRIPTION
## Changes
- Avatar operations: hash → avatarIdentifier
- Profile operations: hash → profileIdentifier
- Updated validation messages to prioritize SHA256 over deprecated MD5
- Updated all tool schemas, handlers, API clients, and tests

## Breaking Change
This is a breaking change for MCP tool parameters. Avatar tools now use avatarIdentifier and profile tools use profileIdentifier instead of the generic hash parameter.

## Validation Updates
- Error messages now emphasize SHA256 as preferred: "Must be a 64-character (SHA256) or 32-character (MD5, deprecated) hexadecimal string"
- Tool descriptions updated to use clearer, context-appropriate language

## Files Changed
- 6 tool files (schemas and handlers)
- AvatarImageApi interface and implementation
- All test files (unit, integration, e2e)
- Tool descriptions and validation messages

## Testing

Tests: ✅ All pass (81/81)
Linting: ✅ Clean
Type Safety: ✅ No TypeScript errors