### PR TITLE
Fix rating validation

### DIFF
--- a/src/apis/avatar-image-api.ts
+++ b/src/apis/avatar-image-api.ts
@@ -1,6 +1,7 @@
 import { validateHash } from '../common/utils.js';
 import { GravatarValidationError } from '../common/errors.js';
-import type { DefaultAvatarOption, Rating } from '../common/types.js';
+import type { DefaultAvatarOption } from '../common/types.js';
+import type { Rating } from '../generated/gravatar-api/models/Rating.js';
 import type { Configuration } from '../generated/gravatar-api/runtime.js';
 
 export interface GetAvatarByIdParams {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,16 +15,6 @@ export enum DefaultAvatarOption {
 }
 
 /**
- * Avatar rating options
- */
-export enum Rating {
-  G = 'g',
-  PG = 'pg',
-  R = 'r',
-  X = 'x',
-}
-
-/**
  * Base API error response structure
  */
 export interface ApiErrorResponse {

--- a/src/tools/get-avatar-by-email.ts
+++ b/src/tools/get-avatar-by-email.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { validateEmail, generateIdentifierFromEmail } from '../common/utils.js';
 import { DefaultAvatarOption } from '../common/types.js';
+import { Rating } from '../generated/gravatar-api/models/Rating.js';
 import { createApiClient } from '../apis/api-client.js';
 
 // Schema definition
@@ -20,16 +21,13 @@ export const getAvatarByEmailSchema = z.object({
     if (val === 'false') return false;
     return val;
   }, z.boolean().optional()),
-  rating: z.preprocess(
-    val => {
-      if (val === '' || val === undefined) return undefined;
-      if (typeof val === 'string') {
-        return val.toUpperCase(); // Normalize to uppercase for validation
-      }
-      return val;
-    },
-    z.enum(['G', 'PG', 'R', 'X']).optional(),
-  ),
+  rating: z.preprocess(val => {
+    if (val === '' || val === undefined) return undefined;
+    if (typeof val === 'string') {
+      return val.toUpperCase(); // Normalize to uppercase for validation
+    }
+    return val;
+  }, z.nativeEnum(Rating).optional()),
 });
 
 // Tool definition

--- a/src/tools/get-avatar-by-id.ts
+++ b/src/tools/get-avatar-by-id.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { validateHash } from '../common/utils.js';
-import { DefaultAvatarOption, Rating } from '../common/types.js';
+import { DefaultAvatarOption } from '../common/types.js';
 import { createApiClient } from '../apis/api-client.js';
 
 // Schema definition
@@ -21,7 +21,16 @@ export const getAvatarByIdSchema = z.object({
     if (val === 'false') return false;
     return val;
   }, z.boolean().optional()),
-  rating: z.preprocess(val => (val === '' ? undefined : val), z.nativeEnum(Rating).optional()),
+  rating: z.preprocess(
+    val => {
+      if (val === '' || val === undefined) return undefined;
+      if (typeof val === 'string') {
+        return val.toUpperCase(); // Normalize to uppercase for validation
+      }
+      return val;
+    },
+    z.enum(['G', 'PG', 'R', 'X']).optional(),
+  ),
 });
 
 // Tool definition

--- a/src/tools/get-avatar-by-id.ts
+++ b/src/tools/get-avatar-by-id.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { validateHash } from '../common/utils.js';
 import { DefaultAvatarOption } from '../common/types.js';
+import { Rating } from '../generated/gravatar-api/models/Rating.js';
 import { createApiClient } from '../apis/api-client.js';
 
 // Schema definition
@@ -21,16 +22,13 @@ export const getAvatarByIdSchema = z.object({
     if (val === 'false') return false;
     return val;
   }, z.boolean().optional()),
-  rating: z.preprocess(
-    val => {
-      if (val === '' || val === undefined) return undefined;
-      if (typeof val === 'string') {
-        return val.toUpperCase(); // Normalize to uppercase for validation
-      }
-      return val;
-    },
-    z.enum(['G', 'PG', 'R', 'X']).optional(),
-  ),
+  rating: z.preprocess(val => {
+    if (val === '' || val === undefined) return undefined;
+    if (typeof val === 'string') {
+      return val.toUpperCase(); // Normalize to uppercase for validation
+    }
+    return val;
+  }, z.nativeEnum(Rating).optional()),
 });
 
 // Tool definition

--- a/test/integration/avatar-image-api-integration.test.ts
+++ b/test/integration/avatar-image-api-integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AvatarImageApi } from '../../src/apis/avatar-image-api.js';
-import { DefaultAvatarOption, Rating } from '../../src/common/types.js';
+import { DefaultAvatarOption } from '../../src/common/types.js';
 import fetch from 'node-fetch';
 
 // Mock the fetch function
@@ -89,12 +89,12 @@ describe('AvatarImageApi Integration', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       });
 
       // Verify the mock was called with the correct URL including query parameters
       expect(fetch).toHaveBeenCalledWith(
-        `https://gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=pg`,
+        `https://gravatar.com/avatar/${hash}?s=200&d=identicon&f=y&r=PG`,
         expect.objectContaining({
           headers: expect.objectContaining({
             'User-Agent': expect.any(String),

--- a/test/unit/avatar-image-api.test.ts
+++ b/test/unit/avatar-image-api.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../src/tools/get-avatar-by-email.js';
 import { GravatarValidationError } from '../../src/common/errors.js';
 import * as utils from '../../src/common/utils.js';
-import { DefaultAvatarOption, Rating } from '../../src/common/types.js';
+import { DefaultAvatarOption } from '../../src/common/types.js';
 import { createMockFetch } from '../helpers/mock-api-clients.js';
 import { createMockAvatarBuffer } from '../helpers/mock-responses.js';
 import { createApiClient } from '../../src/apis/api-client.js';
@@ -152,8 +152,8 @@ describe('AvatarImageApi', () => {
     });
 
     it('should include rating parameter in URL when provided', async () => {
-      await api.getAvatarById({ avatarIdentifier: 'test-hash', rating: Rating.PG });
-      expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?r=pg', {
+      await api.getAvatarById({ avatarIdentifier: 'test-hash', rating: 'PG' });
+      expect(mockFetch).toHaveBeenCalledWith('https://gravatar.com/avatar/test-hash?r=PG', {
         headers: {
           'User-Agent': 'mcp-server-gravatar/v1.0.0',
         },
@@ -166,10 +166,10 @@ describe('AvatarImageApi', () => {
         size: 100,
         defaultOption: DefaultAvatarOption.ROBOHASH,
         forceDefault: true,
-        rating: Rating.G,
+        rating: 'G',
       });
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://gravatar.com/avatar/test-hash?s=100&d=robohash&f=y&r=g',
+        'https://gravatar.com/avatar/test-hash?s=100&d=robohash&f=y&r=G',
         {
           headers: {
             'User-Agent': 'mcp-server-gravatar/v1.0.0',
@@ -314,7 +314,7 @@ describe('Gravatar Image MCP Tools', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       } as any;
 
       await getAvatarByIdHandler(params);
@@ -325,7 +325,7 @@ describe('Gravatar Image MCP Tools', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       });
     });
 
@@ -363,7 +363,7 @@ describe('Gravatar Image MCP Tools', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       } as any;
 
       await getAvatarByEmailHandler(params);
@@ -375,7 +375,7 @@ describe('Gravatar Image MCP Tools', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       });
     });
 

--- a/test/unit/rating-validation.test.ts
+++ b/test/unit/rating-validation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { getAvatarByIdSchema } from '../../src/tools/get-avatar-by-id.js';
+import { getAvatarByEmailSchema } from '../../src/tools/get-avatar-by-email.js';
+
+describe('Rating Validation', () => {
+  const validHash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+  const validEmail = 'test@example.com';
+
+  describe('getAvatarById rating validation', () => {
+    it('should accept valid lowercase ratings (normalized to uppercase)', () => {
+      const testCases = [
+        { input: 'g', expected: 'G' },
+        { input: 'pg', expected: 'PG' },
+        { input: 'r', expected: 'R' },
+        { input: 'x', expected: 'X' },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        const result = getAvatarByIdSchema.parse({
+          avatarIdentifier: validHash,
+          rating: input,
+        });
+        expect(result.rating).toBe(expected);
+      });
+    });
+
+    it('should accept valid uppercase ratings', () => {
+      const validRatings = ['G', 'PG', 'R', 'X'];
+
+      validRatings.forEach(rating => {
+        const result = getAvatarByIdSchema.parse({
+          avatarIdentifier: validHash,
+          rating,
+        });
+        expect(result.rating).toBe(rating);
+      });
+    });
+
+    it('should accept mixed case ratings (normalized to uppercase)', () => {
+      const testCases = [
+        { input: 'Pg', expected: 'PG' },
+        { input: 'pG', expected: 'PG' },
+        { input: 'g', expected: 'G' },
+        { input: 'G', expected: 'G' },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        const result = getAvatarByIdSchema.parse({
+          avatarIdentifier: validHash,
+          rating: input,
+        });
+        expect(result.rating).toBe(expected);
+      });
+    });
+
+    it('should reject invalid ratings', () => {
+      const invalidRatings = ['t', 'invalid', 'z', 'nc17'];
+
+      invalidRatings.forEach(rating => {
+        expect(() => {
+          getAvatarByIdSchema.parse({
+            avatarIdentifier: validHash,
+            rating,
+          });
+        }).toThrow();
+      });
+    });
+
+    it('should handle undefined rating', () => {
+      const result = getAvatarByIdSchema.parse({
+        avatarIdentifier: validHash,
+      });
+      expect(result.rating).toBeUndefined();
+    });
+
+    it('should handle empty string rating (converted to undefined)', () => {
+      const result = getAvatarByIdSchema.parse({
+        avatarIdentifier: validHash,
+        rating: '',
+      });
+      expect(result.rating).toBeUndefined();
+    });
+  });
+
+  describe('getAvatarByEmail rating validation', () => {
+    it('should accept valid lowercase ratings (normalized to uppercase)', () => {
+      const testCases = [
+        { input: 'g', expected: 'G' },
+        { input: 'pg', expected: 'PG' },
+        { input: 'r', expected: 'R' },
+        { input: 'x', expected: 'X' },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        const result = getAvatarByEmailSchema.parse({
+          email: validEmail,
+          rating: input,
+        });
+        expect(result.rating).toBe(expected);
+      });
+    });
+
+    it('should accept valid uppercase ratings', () => {
+      const validRatings = ['G', 'PG', 'R', 'X'];
+
+      validRatings.forEach(rating => {
+        const result = getAvatarByEmailSchema.parse({
+          email: validEmail,
+          rating,
+        });
+        expect(result.rating).toBe(rating);
+      });
+    });
+
+    it('should reject invalid ratings', () => {
+      const invalidRatings = ['t', 'invalid', 'z', 'nc17'];
+
+      invalidRatings.forEach(rating => {
+        expect(() => {
+          getAvatarByEmailSchema.parse({
+            email: validEmail,
+            rating,
+          });
+        }).toThrow();
+      });
+    });
+
+    it('should handle undefined rating', () => {
+      const result = getAvatarByEmailSchema.parse({
+        email: validEmail,
+      });
+      expect(result.rating).toBeUndefined();
+    });
+
+    it('should handle empty string rating (converted to undefined)', () => {
+      const result = getAvatarByEmailSchema.parse({
+        email: validEmail,
+        rating: '',
+      });
+      expect(result.rating).toBeUndefined();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle non-string rating values', () => {
+      expect(() => {
+        getAvatarByIdSchema.parse({
+          avatarIdentifier: validHash,
+          rating: 123,
+        });
+      }).toThrow();
+    });
+
+    it('should handle null rating', () => {
+      expect(() => {
+        getAvatarByIdSchema.parse({
+          avatarIdentifier: validHash,
+          rating: null,
+        });
+      }).toThrow();
+    });
+  });
+});

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -25,7 +25,8 @@ import {
   handler as getAvatarByEmailHandler,
 } from '../../src/tools/get-avatar-by-email.js';
 import { GravatarValidationError } from '../../src/common/errors.js';
-import { DefaultAvatarOption, Rating } from '../../src/common/types.js';
+import { DefaultAvatarOption } from '../../src/common/types.js';
+import type { Rating } from '../../src/generated/gravatar-api/models/Rating.js';
 
 // Mock the utils functions
 vi.mock('../../src/common/utils.js', async () => {
@@ -357,7 +358,7 @@ describe('Avatar Tool Handlers', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG' as Rating,
       };
 
       const result = await getAvatarByIdHandler(params);
@@ -368,7 +369,7 @@ describe('Avatar Tool Handlers', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       });
 
       // Verify response format
@@ -420,7 +421,7 @@ describe('Avatar Tool Handlers', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG' as Rating,
       };
 
       const result = await getAvatarByEmailHandler(params);
@@ -431,7 +432,7 @@ describe('Avatar Tool Handlers', () => {
         size: 200,
         defaultOption: DefaultAvatarOption.IDENTICON,
         forceDefault: true,
-        rating: Rating.PG,
+        rating: 'PG',
       });
 
       // Verify response format


### PR DESCRIPTION
# Fix rating validation

## Problem

- Invalid rating values like `'t'` were not being rejected, causing silent failures
- Custom Rating enum duplicated generated API types

## Solution

__Rating Validation Fix:__

- Added case-insensitive rating validation with proper error handling
- Migrated from custom Rating enum to generated API types for consistency
- Implemented `z.preprocess()` to normalize input (`'g'` → `'G'`, `'pg'` → `'PG'`)
- Invalid ratings now throw clear validation errors
- Added comprehensive test coverage (13 tests) for rating validation

## Changes

- ✅ __Fixed__: Invalid ratings like `'t'` now properly rejected
- ✅ __Enhanced__: Case-insensitive rating input (`'g'` and `'G'` both work)
- ✅ __Migrated__: Uses generated Rating types instead of custom enum
- ✅ __Added__: Comprehensive test coverage (13 rating validation tests)

## Testing

- All 102 tests passing
- New rating validation test suite with edge cases
- Integration tests verify end-to-end behavior
