### PR TITLE
Ensure clean build before publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ inspector:
 # Clean build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
-	rm -rf build/
+	npm run clean
 	rm -rf coverage/
 	rm -rf node_modules/
 	@echo "Clean completed."

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   },
   "scripts": {
     "build": "tsc && chmod +x build/*.js",
+    "clean": "rm -rf build/",
     "prepare": "npm run build",
+    "prepack": "npm run clean && npm run build",
     "start": "node build/index.js",
     "dev": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",


### PR DESCRIPTION
This makes sure that we don't publish any stale files