### PR TITLE
Update README.md to use npm package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Gravatar's official MCP Server, enabling access to avatars, profiles, and inferr
 
 For quick installation in VS Code, click one of the installation buttons below:
 
-[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Configure-0098FF?style=plastic&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=gravatar&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gravatar_api_key%22%2C%22description%22%3A%22Gravatar%20API%20Key%20(optional)%22%2C%22password%22%3Atrue%7D%5D&command=%22npx%22&args=%5B%22-y%22%2C%22github%3AAutomattic%2Fmcp-server-gravatar%22%5D&env=%7B%22GRAVATAR_API_KEY%22%3A%22%24%7Binput%3Agravatar_api_key%7D%22%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Configure-2ABF63?style=plastic&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gravatar&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gravatar_api_key%22%2C%22description%22%3A%22Gravatar%20API%20Key%20(optional)%22%2C%22password%22%3Atrue%7D%5D&command=%22npx%22&args=%5B%22-y%22%2C%22github%3AAutomattic%2Fmcp-server-gravatar%22%5D&env=%7B%22GRAVATAR_API_KEY%22%3A%22%24%7Binput%3Agravatar_api_key%7D%22%7D)
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-Configure-0098FF?style=plastic&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=gravatar&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gravatar_api_key%22%2C%22description%22%3A%22Gravatar%20API%20Key%20(optional)%22%2C%22password%22%3Atrue%7D%5D&command=%22npx%22&args=%5B%22-y%22%2C%22%40automattic%2Fmcp-server-gravatar%22%5D&env=%7B%22GRAVATAR_API_KEY%22%3A%22%24%7Binput%3Agravatar_api_key%7D%22%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Configure-2ABF63?style=plastic&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gravatar&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gravatar_api_key%22%2C%22description%22%3A%22Gravatar%20API%20Key%20(optional)%22%2C%22password%22%3Atrue%7D%5D&command=%22npx%22&args=%5B%22-y%22%2C%22%40automattic%2Fmcp-server-gravatar%22%5D&env=%7B%22GRAVATAR_API_KEY%22%3A%22%24%7Binput%3Agravatar_api_key%7D%22%7D)
 
 ## Requirements
 
@@ -118,7 +118,7 @@ Add the following to your `claude_desktop_config.json`:
       "command": "npx",
       "args": [
         "-y",
-        "github:Automattic/mcp-server-gravatar"
+        "@automattic/mcp-server-gravatar"
       ],
       "env": {
         "GRAVATAR_API_KEY": "your-api-key-here"
@@ -140,7 +140,7 @@ Add the following to your `claude_desktop_config.json`:
       "command": "npx",
       "args": [
         "-y",
-        "github:Automattic/mcp-server-gravatar"
+        "@automattic/mcp-server-gravatar"
       ]
     }
   }
@@ -169,7 +169,7 @@ This configuration prompts for an API key and stores it securely:
     "servers": {
       "gravatar": {
         "command": "npx",
-        "args": ["-y", "github:Automattic/mcp-server-gravatar"],
+        "args": ["-y", "@automattic/mcp-server-gravatar"],
         "env": {
           "GRAVATAR_API_KEY": "${input:gravatar_api_key}"
         }
@@ -190,7 +190,7 @@ This configuration prompts for an API key and stores it securely:
     "servers": {
       "gravatar": {
         "command": "npx",
-        "args": ["-y", "github:Automattic/mcp-server-gravatar"]
+        "args": ["-y", "@automattic/mcp-server-gravatar"]
       }
     }
   }


### PR DESCRIPTION
Based on the work completed in the previous session, here's a succinct PR description for the README.md updates:

---

# Update README.md to use npm package reference

Updates all installation instructions and configuration examples to use the published npm package `@automattic/mcp-server-gravatar` instead of the GitHub reference.

## Changes

- **VS Code Installation Buttons**: Updated shield.io badge URLs to use npm package reference
- **Claude Desktop Configuration**: Updated both "with API key" and "without API key" examples
- **VS Code Configuration**: Updated both manual configuration examples

## Benefits

- ✅ Faster installation via npm registry
- ✅ Better package caching and version management
- ✅ Professional appearance using official npm package
- ✅ Simplified installation commands

## Testing

### Claude Desktop Testing

1. **Backup your current configuration**:
   ```bash
   cp ~/.config/claude-desktop/claude_desktop_config.json ~/.config/claude-desktop/claude_desktop_config.json.backup
   ```

2. **Update your `claude_desktop_config.json`** with the new npm reference:
   ```json
   {
     "mcpServers": {
       "gravatar": {
         "command": "npx",
         "args": ["-y", "@automattic/mcp-server-gravatar"]
       }
     }
   }
   ```

3. **Restart Claude Desktop** completely

4. **Test the MCP server** by asking Claude:
   - "Get my Gravatar profile for email test@example.com"
   - "Show me the avatar for email test@example.com"
   - "What are the inferred interests for email test@example.com"

5. **Verify installation** - Claude should successfully connect to the MCP server and execute the tools without errors
